### PR TITLE
fix netlify build when using cache

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,6 +1,6 @@
 [build]
-  command = "npm run build"
+  command = "npm install && npm run build"
   publish = "dist"
 
 [context.deploy-preview]
-command = "npm run build-preview"
+command = "npm install && npm run build-preview"


### PR DESCRIPTION
To help local testing and do the same on netlify, we are using our own hugo
version fetched with hugo-installer. But netlify builds without a changed
package.json will fails since netlify uses the cache without running npm install
and the hugo binary won't be downloaded.

Fix this forcing running an npm install.