### PR TITLE
synwall: add gitter link

### DIFF
--- a/site/content/projects/synwall.md
+++ b/site/content/projects/synwall.md
@@ -9,4 +9,5 @@ weight: 30
 githubRepo: "SYNwall/SYNwall"
 githubURL: https://github.com/SYNwall/SYNwall
 homeURL: https://synwall.io
+gitterURL: https://gitter.im/SYNwall-random/community
 ---


### PR DESCRIPTION
Add "Get in touch on Gitter" button for SYNWall to projects page.